### PR TITLE
Dev

### DIFF
--- a/.github/workflows/prerelease_build.yml
+++ b/.github/workflows/prerelease_build.yml
@@ -1,0 +1,32 @@
+name: Build and Create Pre-Release
+on:
+  push:
+    branches:
+      - 'dev'
+jobs:
+  build-package:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.2
+      - name: Setup Node
+        uses: actions/setup-node@v4.0.2
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install PyYAML
+      - name: Publish to Visual Studio Marketplace
+        id: publishToVSCMarketplace
+        uses: HaaLeo/publish-vscode-extension@v1.6.2
+        with:
+          pat: ''
+          preRelease: true
+          dryRun: true
+          registryUrl: https://marketplace.visualstudio.com
+      - name: Create Release
+        run: gh release create ${{ github.ref_name }} -p --generate-notes ${{ steps.publishToVSCMarketplace.outputs.vsixPath }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "MapTool-Script Support",
   "description": "Syntax highlighting support for the old MapTool scripting language",
   "icon": "images/logo.png",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "publisher": "bryan-c-jones",
   "repository": {
     "url" : "https://github.com/Daedeross/maptool-script.vscode"

--- a/syntaxes/mts.tmLanguage.json
+++ b/syntaxes/mts.tmLanguage.json
@@ -77,7 +77,7 @@
         },
         "macro-with-roll-options": {
             "name": "meta.macro.roll-options.mts",
-            "match": "(?<=\\[)([^:]+):(.+)(?=])",
+            "match": "(?<=\\[)([^:]+)(:)([^:]+)(?=])",
             "captures": {
                 "1": {
                     "patterns": [
@@ -87,6 +87,9 @@
                     ]
                 },
                 "2": {
+                    "name": "meta.macro.colon.mts"
+                },
+                "3": {
                     "patterns": [
                         {
                             "include": "#statement"

--- a/syntaxes/mts.tmLanguage.yaml
+++ b/syntaxes/mts.tmLanguage.yaml
@@ -142,12 +142,13 @@ repository:
     - include: '#statement'
   macro-with-roll-options:
     name: meta.macro.roll-options.mts
-    match: '(?<=\[)([^:]+):(.+)(?=])'
+    match: '(?<=\[)([^:]+)(:)([^:]+)(?=])'
     captures:
       '1':
         patterns:
         - include: '#roll-options'
-      '2':
+      '2': { name: meta.macro.colon.mts }
+      '3':
         patterns:
         - include: '#statement'
   roll-options:


### PR DESCRIPTION
Fixes #8 under most<sup>TM</sup> circumstances.
Some edge cases will still break due to the limitations of RegEx. Such cases *should* be fixed when TextMate highlighting is removed in favor of **antlr** or **tree-sitter** parsing.